### PR TITLE
Changed CDN to use Jsdelivr instead of raw git

### DIFF
--- a/BetterBadgesGamma.theme.css
+++ b/BetterBadgesGamma.theme.css
@@ -7,10 +7,10 @@
 * @updateUrl https://github.com/ColonelGerdauf/Better-Badges/blob/main/BetterBadgesGamma.theme.css
 */
 
-@import url('https://cdn.jsdelivr.net/gh/ColonelGerdauf/Better-Badges/src/badges.css');
+@import url("https://cdn.jsdelivr.net/gh/ColonelGerdauf/Better-Badges/src/badges.css");
 
 :root{
-    --badge-size: 22px; /* discord defualt = 18px, theme defualt = 22px */
-    --badge-margin: 1.5px; /* discord default = 2px, theme defualt = 1.5px */
+    --badge-size: 22px; /* discord default = 18px, theme default = 22px */
+    --badge-margin: 1.5px; /* discord default = 2px, theme default = 1.5px */
     --badges-everywhere-size: 15px; /* default = 15px */
 }

--- a/BetterBadgesGamma.theme.css
+++ b/BetterBadgesGamma.theme.css
@@ -1,13 +1,14 @@
 /**
 * @name Better Badges Gamma
 * @author Colonel_Gerdauf#8888
-* @version 1.3.2
+* @version 1.3.3
 * @description A theme which adds cool animations to discord's badges!
 * @source https://github.com/ColonelGerdauf/Better-Badges
 * @updateUrl https://github.com/ColonelGerdauf/Better-Badges/blob/main/BetterBadgesGamma.theme.css
 */
 
-@import url('https://raw.githubusercontent.com/ColonelGerdauf/Better-Badges/main/src/badges.css');
+@import url('https://cdn.jsdelivr.net/gh/ColonelGerdauf/Better-Badges/src/badges.css');
+
 :root{
     --badge-size: 22px; /* discord defualt = 18px, theme defualt = 22px */
     --badge-margin: 1.5px; /* discord default = 2px, theme defualt = 1.5px */


### PR DESCRIPTION
raw.githubusercontent.com is not meant for CDN and does not work if the MIME type should be other than text/plain.

Discord does use strict MIME (MIME type ('text/plain') is not a supported stylesheet MIME type, and strict MIME checking is enabled.) so switching to a real CDN will fix this issue. Also jsdelivr is a better caching tool and does have fast content load.

Thanks for having this forked version btw :)